### PR TITLE
Default browse_root to curdir.

### DIFF
--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -37,7 +37,9 @@ class AutoIndex(object):
         AutoIndex(app, '/home/someone/public_html', add_url_rules=True)
 
     :param base: a Flask application.
-    :param browse_root: a path which is served by root address.
+    :param browse_root: a path which is served by root address. By default,
+                        this is the working directory, but you can set it to
+                        fix your app to always use one location if you like.
     :param add_url_rules: if it is ``True``, the wrapped application routes
                           ``/`` and ``/<path:path>`` to autoindex. default
                           is ``True``.
@@ -78,7 +80,7 @@ class AutoIndex(object):
             browse_root = str(browse_root)
             self.rootdir = RootDirectory(browse_root, autoindex=self)
         else:
-            self.rootdir = None
+            self.rootdir = os.path.curdir
         self.template_context = template_context
         if silk_options is None:
             silk_options = {}

--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -78,9 +78,9 @@ class AutoIndex(object):
         self.base = base
         if browse_root:
             browse_root = str(browse_root)
-            self.rootdir = RootDirectory(browse_root, autoindex=self)
         else:
-            self.rootdir = os.path.curdir
+            browse_root = os.path.curdir
+        self.rootdir = RootDirectory(browse_root, autoindex=self)
         self.template_context = template_context
         if silk_options is None:
             silk_options = {}

--- a/flask_autoindex/run.py
+++ b/flask_autoindex/run.py
@@ -3,10 +3,8 @@ from flask import Flask
 from flask.ext.autoindex import AutoIndex
 
 
-def run():
-    app = Flask(__name__)
-    AutoIndex(app, browse_root=os.path.curdir)
-    app.run()
+app = Flask(__name__)
+AutoIndex(app)
 
 if __name__ == '__main__':
-    run()
+    app.run()


### PR DESCRIPTION
The examples all show setting `browse_root` to something explicitly, and I discovered by trial and error that in fact there is no default---the server comes up, but gives 500s.  My unix intuition assumed that it would working in the working directory unless told otherwise---that's how other small webservers, like thttpd and webfsd and http/server.py work, afterall.

What do you think?