### PR TITLE
Fix console_scripts to run command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'fai = flask_autoindex.run:run',
+            'fai = flask_autoindex.run:app.run',
         ],
     },
 )


### PR DESCRIPTION
I have below error:
```
% fai
/usr/local/lib/python2.7/dist-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.autoindex is deprecated, use flask_autoindex instead.
  .format(x=modname), ExtDeprecationWarning
Traceback (most recent call last):
  File "/home/wkentaro/.local/bin/fai", line 11, in <module>
    load_entry_point('Flask-AutoIndex==0.6', 'console_scripts', 'fai')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 564, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2621, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2281, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2291, in resolve
    raise ImportError(str(exc))
ImportError: 'module' object has no attribute 'run'
```