### PR TITLE
Add version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],


### PR DESCRIPTION
It looks like this project is now Python 3 compatible. Adding the version classifiers helps to show this on the PyPI project page and using tools such as [caniusepython3](https://caniusepython3.com/)