### PR TITLE
Enable 'sort_by' and 'order' to be called from the AutoIndex()

### DIFF
--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -74,7 +74,7 @@ class AutoIndex(object):
 
     def __init__(self, base, browse_root=None, add_url_rules=True,
                  template_context=None, silk_options=None,
-                 show_hidden=False):
+                 show_hidden=False, sort_by='name', order=1):
         """Initializes an autoindex instance."""
         self.base = base
         if browse_root:
@@ -94,7 +94,7 @@ class AutoIndex(object):
             @self.base.route('/')
             @self.base.route('/<path:path>')
             def autoindex(path='.'):
-                return self.render_autoindex(path)
+                return self.render_autoindex(path, sort_by=sort_by, order=order)
 
     def render_autoindex(self, path, browse_root=None, template=None,
                          template_context=None, endpoint='.autoindex',

--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -98,7 +98,7 @@ class AutoIndex(object):
 
     def render_autoindex(self, path, browse_root=None, template=None,
                          template_context=None, endpoint='.autoindex',
-                         show_hidden=None, sort_by='name',
+                         show_hidden=None, sort_by='name', order=1,
                          mimetype=None):
         """Renders an autoindex with the given path.
 
@@ -129,12 +129,7 @@ class AutoIndex(object):
 
         if os.path.isdir(abspath):
             sort_by = request.args.get('sort_by', sort_by)
-            if sort_by[0] in ['-', '+']:
-                order = {'+': 1, '-': -1}[sort_by[0]]
-                sort_by = sort_by[1::]
-            else:
-                order = {'asc': 1, 'desc': -
-                         1}[request.args.get('order', 'asc')]
+            order = {'asc': 1, 'desc': -1, 'default': order}[request.args.get('order', 'default')]
             curdir = Directory(path, rootdir)
             if show_hidden == None:
                 show_hidden = self.show_hidden


### PR DESCRIPTION
This RP contains two commits

--------------------------------------------
Commit 59250b7eb7f028bdb585d88d6e8c283278264626 enables `render_autoindex()` to be called with `sort_by` and `order`

```py
@app.route('/')
@app.route('/<path:path>')
def autoindex(path='.'):
    return app.render_autoindex(path, sort_by='name', order=1)
```
Note that this commit would effectively nullify PR #43 , the reason for this is to maintain argument consistency with `Entry.explorer()`

--------------------------------------------
Commit fe5fb8911620c6fd3149062c914a04a82947fecc let you specify sorting order when initializing the app.
So something like below is possible:
```py
AutoIndex(app, browse_root='/', sort_by='name', order=-1)
```
